### PR TITLE
Add component versions in field definitions

### DIFF
--- a/etc/ceilometer/monasca_field_definitions.yaml
+++ b/etc/ceilometer/monasca_field_definitions.yaml
@@ -37,6 +37,12 @@ metadata:
         - longitude
         - ram_allocation_ratio
         - cpu_allocation_ratio
+        - ceilometer_version
+        - keystone_version
+        - neutron_version
+        - cinder_version
+        - nova_version
+        - glance_version
     image:
         - size
         - status


### PR DESCRIPTION
Please merge this PR. It introduce the changes to support new fields definitions related to components versions retrieved by the new region pollster available here: https://github.com/SmartInfrastructures/ceilometer-plugin-fiware/tree/compversion/region
